### PR TITLE
Update documentation for Dataverse content and file size info retriev…

### DIFF
--- a/doc/sphinx-guides/source/api/native-api.rst
+++ b/doc/sphinx-guides/source/api/native-api.rst
@@ -64,7 +64,7 @@ Show Contents of a Dataverse
 
 |CORS| Lists all the DvObjects under dataverse ``id``. ::
 
-    GET http://$SERVER/api/dataverses/$id/contents
+``curl -H "X-Dataverse-key:$API_TOKEN" http://$SERVER_URL/api/dataverses/$id/contents``
 
 
 Report the data (file) size of a Dataverse
@@ -72,7 +72,7 @@ Report the data (file) size of a Dataverse
 
 Shows the combined size in bytes of all the files uploaded into the dataverse ``id``. ::
 
-    GET http://$SERVER/api/dataverses/$id/storagesize
+``curl -H "X-Dataverse-key:$API_TOKEN" http://$SERVER_URL/api/dataverses/$id/storagesize``
 
 Both published and unpublished files will be counted, in the dataverse specified, and in all its sub-dataverses, recursively. 
 By default, only the archival files are counted - i.e., the files uploaded by users (plus the tab-delimited versions generated for tabular data files on ingest). If the optional argument ``includeCached=true`` is specified, the API will also add the sizes of all the extra files generated and cached by Dataverse - the resized thumbnail versions for image files, the metadata exports for published datasets, etc. 


### PR DESCRIPTION
…al for Native API

If API Key is not provided, in 'Show Contents of a Dataverse' and 'Report the data (file) size of a Dataverse' calls from Native API, returned data does not reflect dataverse status:

 'Show Contents of a Dataverse'
curl -X GET \
  http://localhost:8888/api/dataverses/3/contents \
  -H 'cache-control: no-cache'
returns:
{
    "status": "OK",
    "data": []
}
, although it contained unpublished datasets.

'Report the data (file) size of a Dataverse'
curl -X GET http://localhost:8888/api/dataverses/3/storagesize \
  -H 'cache-control: no-cache'

returns:
{
    "status": "ERROR",
    "message": "User :guest is not permitted to perform requested action."
}

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- #ISSUE_NUMBER: ISSUE_TITLE

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: http://guides.dataverse.org/en/latest/developers/sql-upgrade-scripts.html
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/7.3.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
